### PR TITLE
Only use the commit title to find upstream commits

### DIFF
--- a/autosquash.go
+++ b/autosquash.go
@@ -34,7 +34,7 @@ func main() {
 		}
 
 		if strings.HasPrefix(commit.Message, fixupPrefix) || strings.HasPrefix(commit.Message, squashPrefix) {
-			messageWithoutPrefix := trimPrefix(commit.Message)
+			messageWithoutPrefix := commitTitle(trimPrefix(commit.Message))
 			autosquashCommitMessages = append(autosquashCommitMessages, messageWithoutPrefix)
 		}
 
@@ -71,6 +71,10 @@ func main() {
 
 func printf(format string, args ...interface{}) {
 	fmt.Printf("%s\n", fmt.Sprintf(format, args...))
+}
+
+func commitTitle(commitMessage string) string {
+	return strings.Split(strings.ReplaceAll(commitMessage, "\r\n", "\n"), "\n")[0]
 }
 
 func trimPrefix(commitMessage string) string {


### PR DESCRIPTION
If the fixup! or squash! commit has a description or even just a newline, it won't necessary match the upstream commit.